### PR TITLE
feat: add sklearnserver rockcraft.yaml

### DIFF
--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,0 +1,78 @@
+name: sklearnserver
+summary: An image for Seldon SKLearn Server
+description: |
+  This image is used as part of the Charmed Kubeflow product. The SKLearn Server serves
+  models which have been stored as pickles.
+version: v1.16.0_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
+license: Apache-2.0
+base: ubuntu:20.04
+services:
+  sklearnserver:
+    override: replace
+    summary: "sklearnserver service"
+    startup: enabled
+    # Yet again, use a subshell to jam conda into a working state. Can't use bashrc, because it immediately
+    # exits if PS1 isn't set, so no-go from scripts
+    command: bash -c 'cd /microservice && export PATH=/opt/conda/bin/${PATH} && eval $(/opt/conda/bin/conda shell.bash hook 2> /dev/null) && source /opt/conda/etc/profile.d/conda.sh && conda activate && seldon-core-microservice $MODEL_NAME --service-type $SERVICE_TYPE --persistence $PERSISTENCE'
+    environment:
+      MODEL_NAME: "SKLearnServer"
+      SERVICE_TYPE: "MODEL"
+      PERSISTENCE: "0"
+platforms:
+  amd64:
+
+parts:
+  sklearnserver:
+    plugin: nil
+    source: https://github.com/SeldonIO/seldon-core
+    source-type: git
+    source-tag: v1.16.0
+    override-stage: |
+      export CONDA_DOWNLOAD_VERSION="py38_4.12.0"
+      export CONDA_VERSION="4.13.0"
+      curl -L -o certifi-python-certifi.tar.gz https://github.com/certifi/python-certifi/archive/master.tar.gz
+      curl -L -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_DOWNLOAD_VERSION}-Linux-x86_64.sh
+      bash ~/miniconda.sh -b -u -p opt/conda
+      rm ~/miniconda.sh
+      opt/conda/bin/conda install --yes conda=${CONDA_VERSION}
+      opt/conda/bin/conda clean -tipy
+
+      mkdir -p etc/profile.d
+      ln -sf opt/conda/etc/profile.d/conda.sh etc/profile.d/conda.sh
+      echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
+      bash -c "opt/conda/bin/conda init bash"
+      echo "conda activate base" >> ~/.bashrc
+      chgrp -R root opt/conda && chmod -R g+rw opt/conda
+
+      # Use a heredoc to build a temporary script. Craft stages use sh, not bash.
+      cat >> ./build.sh <<EOF
+      #!/usr/bin/bash
+      export PWD=$(pwd)
+      export PATH=./opt/conda/bin:${PATH}
+      eval $(/root/stage/opt/conda/bin/conda shell.bash hook 2> /dev/null)
+
+      conda activate
+      conda activate base
+      cd /root/parts/sklearnserver/src/servers/sklearnserver/sklearnserver
+      pip install -r requirements.txt
+
+      mkdir -p ${PWD}/microservice
+      cp SKLearnServer.py ${PWD}/microservice/
+      EOF
+
+      bash ./build.sh
+      rm build.sh
+
+      # conda writes shebangs with its path everywhere, and in crafting, that will be, for example:
+      # #!/root/stage/opt/conda/...
+      #
+      # Snip off the /root/stage part
+      bash -c "grep -R -E '/root/stage' opt/ 2>/dev/null | grep -v Bin | awk '{split(\$0,out,\":\"); print out[1]}' | uniq | xargs -I{} sed -i -e 's/\/root\/stage//' {}"
+    override-prime: |
+      craftctl default
+      cp -rp ${CRAFT_STAGE}/opt opt/
+
+      # seldon-core-microservice is a trivial wrapper which looks for .py|.exe files in pwd
+      # and blindly executes them, as they should inherit. It doesn't need to be in /microservice,
+      # but it does need to match pebble's workdir
+      install -D -m 755 ${CRAFT_STAGE}/microservice/SKLearnServer.py microservice/SKLearnServer.py

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -87,7 +87,7 @@ parts:
 
   non-root-user:
     plugin: nil
-    after: [<build-part-name>]
+    after: sklearnserver
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -18,6 +18,8 @@ services:
       MODEL_NAME: "SKLearnServer"
       SERVICE_TYPE: "MODEL"
       PERSISTENCE: "0"
+    user: ubuntu
+
 platforms:
   amd64:
 
@@ -76,3 +78,17 @@ parts:
       # and blindly executes them, as they should inherit. It doesn't need to be in /microservice,
       # but it does need to match pebble's workdir
       install -D -m 755 ${CRAFT_STAGE}/microservice/SKLearnServer.py microservice/SKLearnServer.py
+
+      # security requirement
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/ROCK images
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/ROCK images/dpkg.query
+
+  non-root-user:
+    plugin: nil
+    after: [<build-part-name>]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu


### PR DESCRIPTION
Adds sklearnserver rockcraft.yaml

##### Instructions to test

1. Build the rock
```
rockcraft pack -v
```
3. Import the rock into a local docker registry
```
# This step requires you to install skopeo, which you can do with apt on Ubuntu 20.04 or newer
# https://github.com/containers/skopeo/blob/main/install.md
sudo skopeo --insecure-policy copy oci-archive:<name of the rock file>.rock docker-daemon:<img name>:0.1
```
4. Run the container image
```
docker run --rm <img name>:0.1
```
##### Output
