### PR TITLE
feat: added seldon rocks to scan workflow

### DIFF
--- a/.github/workflows/build_and_scan_rocks.yaml
+++ b/.github/workflows/build_and_scan_rocks.yaml
@@ -14,6 +14,10 @@ jobs:
     strategy:
       matrix:
         rock:
+          - mlserver-huggingface
+          - mlserver-mlflow
+          - mlserver-sklearn
+          - mlserver-xgboost
           - seldon-core-operator
           - sklearnserver
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_scan_rock.yaml@main


### PR DESCRIPTION

Adding ROCKs to weekly CVE scan is part of ROCK delivery.
Details are in https://github.com/canonical/seldon-core-operator/issues/133

Summary of changes:
- Added Seldon ROCKs to weekly scan.