### PR TITLE
fix: updated workflow to disable parallel

### DIFF
--- a/.github/workflows/build_and_scan_rocks.yaml
+++ b/.github/workflows/build_and_scan_rocks.yaml
@@ -20,6 +20,7 @@ jobs:
           - mlserver-xgboost
           - seldon-core-operator
           - sklearnserver
+      max-parallel: 1
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_scan_rock.yaml@main
     secrets:
       JIRA_URL: ${{ secrets.CVE_REPORT_JIRA_URL }}


### PR DESCRIPTION
# Description

Number of ROCKs in the repository has increased. Due to parallel execution of building and scanning of ROCKs GH runner resources were exhausted and many ROCKs were not built or scanned.

# Solution

Disable parallel execution of matrix of ROCKs. This will slow down the process, but will allow it to fnish properly. This is acceptable solution, because this workflow will run on weekly schedule and is not time sensitive.

Summary of changes:
- Updated workflow to disable parallel run of matrix due to resouces limitation in GH.