### PR TITLE
sklearnserver: Update ROCK

### DIFF
--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,4 +1,5 @@
-# Based on https://github.com/SeldonIO/seldon-core/tree/master/servers/sklearnserver/sklearnserver
+# Based on https://github.com/SeldonIO/seldon-core/tree/master/servers/sklearnserver
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Makefile
 # Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile.conda
 # Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile
 name: sklearnserver

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,4 +1,6 @@
 # Based on https://github.com/SeldonIO/seldon-core/tree/master/servers/sklearnserver/sklearnserver
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile.conda
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile
 name: sklearnserver
 summary: An image for Seldon SKLearn Server
 description: |
@@ -15,7 +17,8 @@ services:
     startup: enabled
     # Yet again, use a subshell to jam conda into a working state. Can't use bashrc, because it immediately
     # exits if PS1 isn't set, so no-go from scripts.
-    command: bash -c 'cd /microservice && export PATH=/opt/conda/bin/:${PATH} && eval $(/opt/conda/bin/conda shell.bash hook 2> /dev/null) && source /opt/conda/etc/profile.d/conda.sh && conda activate && seldon-core-microservice ${MODEL_NAME} --service-type ${SERVICE_TYPE} &> /tmp/log.txt'
+    command: bash -c 'export PATH=/opt/conda/bin/:${PATH} && eval $(/opt/conda/bin/conda shell.bash hook 2> /dev/null) && source /opt/conda/etc/profile.d/conda.sh && conda activate && seldon-core-microservice ${MODEL_NAME} --service-type ${SERVICE_TYPE} &> /tmp/log.txt'
+    working-dir: "/microservice"
     environment:
       # the following environment variables are taken from:
       # https://github.com/SeldonIO/seldon-core/blob/master/servers/sklearnserver/environment
@@ -38,19 +41,28 @@ parts:
       curl -L -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_DOWNLOAD_VERSION}-Linux-x86_64.sh
       bash ~/miniconda.sh -b -u -p opt/conda
       rm ~/miniconda.sh
+      # Omit usage of conda-forge channel due to security reasons
+      # since it is a community-maintained collection of packages.
       opt/conda/bin/conda install --yes conda=${CONDA_VERSION}
       opt/conda/bin/conda clean -tipy
 
       mkdir -p etc/profile.d
       ln -sf opt/conda/etc/profile.d/conda.sh etc/profile.d/conda.sh
       echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
-      bash -c "opt/conda/bin/conda init bash"
       echo "conda activate base" >> ~/.bashrc
       chgrp -R root opt/conda && chmod -R g+rw opt/conda
+      # Skip the TINI part since this is the Entrypoint for the intermediate base image
 
-      # Use a heredoc to build a temporary script. Craft stages use sh, not bash.
+      # Configure shell to use `conda activate`. `conda init` also requires a restart
+      # of the shell afterwards. That's why we use a script to run the commands below
+      bash -c "opt/conda/bin/conda init bash"
+
+      # Use a heredoc to build a temporary script. This will start a new shell session.
+      # Install requirements in conda environment (also installs seldon-core-microservice)
       cat >> ./build.sh <<EOF
       #!/usr/bin/bash
+      # Make sure `rockcraft` will exit on script errors.
+      set -e
       export PWD=$(pwd)
       export PATH=./opt/conda/bin:${PATH}
       eval $(/root/stage/opt/conda/bin/conda shell.bash hook 2> /dev/null)
@@ -81,6 +93,8 @@ parts:
       # and blindly executes them, as they should inherit. It doesn't need to be in /microservice,
       # but it does need to match pebble's workdir
       install -D -m 755 ${CRAFT_STAGE}/microservice/SKLearnServer.py microservice/SKLearnServer.py
+      # We do not install seldon-core-microservice using `pip install .` like upstream
+      # since we use the one installed in Conda environment during pip install -r requirements.txt
 
   security-team-requirement:
     plugin: nil

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -58,6 +58,8 @@ parts:
       conda activate
       conda activate base
       cd /root/parts/sklearnserver/src/servers/sklearnserver/sklearnserver
+      # Below version should match the source-tag
+      sed -i 's/seldon_core/seldon_core == 1.16.0/g' requirements.txt
       pip install -r requirements.txt
 
       mkdir -p ${PWD}/microservice

--- a/sklearnserver/tox.ini
+++ b/sklearnserver/tox.ini
@@ -23,6 +23,7 @@ deps =
     pytest
     pytest-operator
     ops
+    charmed_kubeflow_chisme
 commands =
     # build and pack rock
     rockcraft pack
@@ -71,5 +72,5 @@ commands =
     # replace yq safe placeholder with original value
     sed -i "s/namespace: YQ_SAFE/namespace: {{ namespace }}/" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    tox -c {env:LOCAL_CHARM_DIR} -e seldon-servers-integration
 


### PR DESCRIPTION
This PR started as an effort to resolve this https://github.com/canonical/seldonio-rocks/issues/44 but it looks like our initial understanding was not quite right. Thus, we created https://github.com/canonical/seldonio-rocks/issues/47 where we documented how this ROCK is implemented at the moment. At the same time, we 're updating the `rockcraft.yaml` file with:
- Sufficient comments about implementation
- Pinning `seldon_core` dependency in order to use `seldon-core-microservice` of the same version as the server built.
- Use `working-dir` instead of `cd`
- Update integration tests command and unit tests deps

Closes #44, #47 
We can always use the latter in order to add more implementation details in the future.

### Testing
Manually ran tests successfully from `sklearnserver` directory (both unit and integration). 