### PR TITLE
feat: Update `on_pull_request` and introduce `on_push` workflow

### DIFF
--- a/.github/workflows/build_and_publish_rock.yaml
+++ b/.github/workflows/build_and_publish_rock.yaml
@@ -4,7 +4,7 @@ name: Build and publish rock
 on:
   workflow_call:
     inputs:
-      rockcraft-dir:
+      rock-dir:
         description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
         required: true
         default: '.'
@@ -16,7 +16,7 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      rockcraft-dir:
+      rock-dir:
         description: "Path to rock directory, i.e. directory containing rockcraft.yaml"
         required: true
         default: '.'
@@ -32,7 +32,7 @@ jobs:
     name: Build and publish ROCK
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_publish_rock.yaml@main
     with:
-      rockcraft-dir: ${{ inputs.rockcraft-dir }}
+      rock-dir: ${{ inputs.rock-dir }}
       source-branch: ${{ inputs.source-branch }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -5,10 +5,13 @@ on:
 
 jobs:
 
-  get-rocks-modified-and-build-scan-test:
+  on-pull-request:
     name: Get ROCKs modified and build-scan-test them
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get_rocks_modified_and_build_scan_test.yaml@main
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
+    permissions:
+      pull-requests: read
     secrets: inherit
     with:
-      microk8s-channel: 1.24/stable
-      juju-channel: 2.9/stable
+      microk8s-channel: 1.26/stable
+      juju-channel: 3.1/stable
+      python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,4 +1,4 @@
-name: On Pull Request
+name: On Push
 
 on:
   push:

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,20 @@
+name: On Pull Request
+
+on:
+  push:
+    branches:
+    - main
+    - track/**
+
+jobs:
+
+  on-push:
+    name: Get ROCKs modified and build-scan-test-publish them
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
+    permissions:
+      pull-requests: read
+    secrets: inherit
+    with:
+      microk8s-channel: 1.26/stable
+      juju-channel: 3.1/stable
+      python-version: "3.8"


### PR DESCRIPTION
Update repo's CI according to changes introduced in PR https://github.com/canonical/charmed-kubeflow-workflows/pull/36. This could be considered a follow up PR to https://github.com/canonical/seldonio-rocks/pull/64 that closed https://github.com/canonical/seldonio-rocks/issues/58. 

After this PR, automation will be set up according to https://github.com/canonical/charmed-kubeflow-workflows/issues/31#issuecomment-1851982000. 
