### PR TITLE
chore: bump seldon-core-operator 1.15.x -> 1.17.1

### DIFF
--- a/seldon-core-operator/rockcraft.yaml
+++ b/seldon-core-operator/rockcraft.yaml
@@ -1,3 +1,4 @@
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.17.1/operator/Dockerfile
 name: seldon-core-operator
 summary: Convert your ML models or language wrappers into microservices
 description: |
@@ -9,10 +10,9 @@ description: |
   provides advanced machine learning capabilities out of the box including
   Advanced Metrics, Request Logging, Explainers, Outlier Detectors, A/B Tests,
   Canaries and more.
-
-version: v1.15.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: 1.17.1
 license: Apache-2.0
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 base: bare
 run-user: _daemon_
 services:
@@ -29,7 +29,7 @@ parts:
     plugin: go
     source: https://github.com/SeldonIO/seldon-core
     source-type: git
-    source-tag: v1.15.0
+    source-tag: v1.17.1
     build-snaps:
       - go
       - kustomize/latest/stable

--- a/seldon-core-operator/tests/test_rock.py
+++ b/seldon-core-operator/tests/test_rock.py
@@ -37,7 +37,8 @@ def test_rock(rock_test_env):
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    rockfs_tar = temp_dir.join("rockfs.tar")
+    # rockfs_tar = temp_dir.join("rockfs.tar")
+    rockfs_tar = "rockfs.tar"
     rockfs_dir = temp_dir.mkdir("rockfs")
 
     # verify that ROCK service matches charm service
@@ -59,3 +60,5 @@ def test_rock(rock_test_env):
     assert "configmap.yaml" in files
     assert "validate.yaml" in files
     assert "crd-v1.yaml" in files
+
+    subprocess.run(["rm",rockfs_tar], check=True)

--- a/seldon-core-operator/tests/test_rock.py
+++ b/seldon-core-operator/tests/test_rock.py
@@ -14,7 +14,6 @@ import pytest
 import string
 import subprocess
 import yaml
-from pytest_operator.plugin import OpsTest
 from charmed_kubeflow_chisme.rock import CheckRock
 
 @pytest.fixture()
@@ -30,12 +29,13 @@ def rock_test_env(tmpdir):
     # tmpdir fixture we use here should clean up the other files for us
 
 @pytest.mark.abort_on_fail
-def test_rock(ops_test: OpsTest, rock_test_env):
+def test_rock(rock_test_env):
     """Test rock."""
     temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
-    rock_image = check_rock.get_image_name()
+    rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
     rockfs_tar = temp_dir.join("rockfs.tar")
     rockfs_dir = temp_dir.mkdir("rockfs")
@@ -46,7 +46,7 @@ def test_rock(ops_test: OpsTest, rock_test_env):
     assert rock_services["seldon-core"]["startup"] == "enabled"
 
     # create ROCK filesystem
-    subprocess.run(["docker", "create", f"--name={container_name}", f"{rock_image}:{rock_version}"])
+    subprocess.run(["docker", "create", f"--name={container_name}", LOCAL_ROCK_IMAGE])
     subprocess.run(["docker", "export", f"{container_name}", "--output", rockfs_tar], check=True)
     subprocess.run(["tar", "xvf", rockfs_tar, "-C", rockfs_dir], check=True)
 

--- a/seldon-core-operator/tox.ini
+++ b/seldon-core-operator/tox.ini
@@ -13,38 +13,37 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+    skopeo
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar'
-    # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \\
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *
 deps =
-    juju~=2.9.0
     pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+    git+https://github.com/canonical/charmed-kubeflow-chisme.git@main
+    # Remove above line and uncomment below once we publish
+    # https://github.com/canonical/charmed-kubeflow-chisme/pull/81
+    # charmed_kubeflow_chisme
 commands =
     # run rock tests
     pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
@@ -56,27 +55,21 @@ allowlist_externals =
     git
     rm
     tox
-    rockcraft
 deps =
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
     # clone related charm
     rm -rf {env:LOCAL_CHARM_DIR}
     git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
     # upload rock to docker and microk8s cache, replace charm's container with local rock reference
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar && \
-             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/metadata.yaml'
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+             sudo microk8s ctr image import $DOCKER_IMAGE.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$DOCKER_IMAGE\"" {env:LOCAL_CHARM_DIR}/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
-
+    tox -c {env:LOCAL_CHARM_DIR} -e charm-integration


### PR DESCRIPTION
Bump ROCK version. On top of that:
- refactor tox.ini according to https://github.com/canonical/oidc-authservice-rock/pull/14 and https://github.com/canonical/bundle-kubeflow/issues/763
- update `test_rock.py` according to latest changes in chisme https://github.com/canonical/charmed-kubeflow-chisme/pull/81
- modify `docker export` command because it failed to access `tmp_dir`

Details for changes in https://github.com/canonical/seldonio-rocks/issues/37#issuecomment-1714077102. (old comments about SeldonDeployments failing are irrelevant now).
Closes https://github.com/canonical/seldonio-rocks/issues/55