### PR TITLE
chore: bump sklearnserver for Seldon version 1.15.x -> 1.17.1

### DIFF
--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,15 +1,15 @@
 # Based on https://github.com/SeldonIO/seldon-core/tree/master/servers/sklearnserver
-# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Makefile
-# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile.conda
-# Based on https://github.com/SeldonIO/seldon-core/blob/v1.16.0/wrappers/s2i/python/Dockerfile
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.17.1/wrappers/s2i/python/Makefile
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.17.1/wrappers/s2i/python/Dockerfile
+# Based on https://github.com/SeldonIO/seldon-core/blob/v1.17.1/wrappers/s2i/python/Dockerfile.conda
 name: sklearnserver
 summary: An image for Seldon SKLearn Server
 description: |
   This image is used as part of the Charmed Kubeflow product. The SKLearn Server serves
   models which have been stored as pickles.
-version: v1.16.0_20.04_1 # <upstream-version>_<base-version>_<Charmed-KF-version>
+version: 1.17.1
 license: Apache-2.0
-base: ubuntu:20.04
+base: ubuntu@20.04
 run-user: _daemon_
 services:
   sklearnserver:
@@ -34,10 +34,10 @@ parts:
     plugin: nil
     source: https://github.com/SeldonIO/seldon-core
     source-type: git
-    source-tag: v1.16.0
+    source-tag: v1.17.1
     override-stage: |
-      export CONDA_DOWNLOAD_VERSION="py38_4.12.0"
-      export CONDA_VERSION="4.13.0"
+      export CONDA_DOWNLOAD_VERSION="py38_23.3.1-0"
+      export CONDA_VERSION="23.5.0"
       curl -L -o certifi-python-certifi.tar.gz https://github.com/certifi/python-certifi/archive/master.tar.gz
       curl -L -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_DOWNLOAD_VERSION}-Linux-x86_64.sh
       bash ~/miniconda.sh -b -u -p opt/conda

--- a/sklearnserver/tests/test_rock.py
+++ b/sklearnserver/tests/test_rock.py
@@ -14,13 +14,12 @@ import pytest
 import string
 import subprocess
 import yaml
-from pytest_operator.plugin import OpsTest
 
 @pytest.fixture()
-def rock_test_env():
+def rock_test_env(tmpdir):
     """Yields a temporary directory and random docker container name, then cleans them up after."""
     container_name = "".join([str(i) for i in random.choices(string.ascii_lowercase, k=8)])
-    yield container_name
+    yield tmpdir, container_name
 
     try:
         subprocess.run(["docker", "rm", container_name])
@@ -28,11 +27,13 @@ def rock_test_env():
         pass
 
 @pytest.mark.abort_on_fail
-def test_rock(ops_test: OpsTest, rock_test_env):
+def test_rock(rock_test_env):
     """Test rock."""
+    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
-    container_name = rock_test_env
-    LOCAL_ROCK_IMAGE = f"{check_rock.get_image_name()}:{check_rock.get_version()}"
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
     # verify that all artifacts are in correct locations
     subprocess.run(["docker", "run", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/microservice/SKLearnServer.py"], check=True)

--- a/sklearnserver/tox.ini
+++ b/sklearnserver/tox.ini
@@ -13,38 +13,37 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+    skopeo
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION'
-
-    # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \\
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *
 deps =
-    juju~=2.9.0
     pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+    git+https://github.com/canonical/charmed-kubeflow-chisme.git@main
+    # Remove above line and uncomment below once we publish
+    # https://github.com/canonical/charmed-kubeflow-chisme/pull/81
+    # charmed_kubeflow_chisme
 commands =
     # run rock tests
     pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
@@ -56,16 +55,13 @@ allowlist_externals =
     git
     rm
     tox
-    rockcraft
     sed
 deps =
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
     # clone related charm
     rm -rf {env:LOCAL_CHARM_DIR}
     git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
@@ -74,16 +70,14 @@ commands =
     # upload rock to docker and microk8s cache, replace charm's container with local rock reference
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar --digests=true && \
-	     predictor_servers=$(yq e ".data.predictor_servers" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2) && \
-             predictor_servers=$(jq --arg jq_rock $ROCK -r '\''.SKLEARN_SERVER.protocols.seldon.image=$jq_rock'\'' <<< $predictor_servers) && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+             sudo microk8s ctr image import $DOCKER_IMAGE.tar && \
+
+    	     predictor_servers=$(yq e ".data.predictor_servers" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2) && \
+             predictor_servers=$(jq --arg jq_name $NAME -r '\''.SKLEARN_SERVER.protocols.seldon.image=$jq_name'\'' <<< $predictor_servers) && \
              predictor_servers=$(jq --arg jq_version $VERSION -r '\''.SKLEARN_SERVER.protocols.seldon.defaultImageVersion=$jq_version'\'' <<< $predictor_servers) yq e -i ".data.predictor_servers=strenv(predictor_servers)" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2'
     # replace yq safe placeholder with original value
     sed -i "s/namespace: YQ_SAFE/namespace: {{ namespace }}/" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e seldon-servers-integration
-
+    tox -c {env:LOCAL_CHARM_DIR} -e seldon-servers-integration -- -k sklearn-v1


### PR DESCRIPTION
Update ROCK according to upstream changes but also:
- refactor tox.ini according to https://github.com/canonical/oidc-authservice-rock/pull/14 and https://github.com/canonical/bundle-kubeflow/issues/763
- update `test_rock.py` according to latest changes in chisme https://github.com/canonical/charmed-kubeflow-chisme/pull/81 + some nit changes about following the same pattern with the rest of `test_rock.py` in this repo.

Refs https://github.com/canonical/seldonio-rocks/issues/37
Closes https://github.com/canonical/seldonio-rocks/issues/52