### PR TITLE
chore: bump tensorflow-serving for Seldon version 1.15.x -> 1.17.1 

### DIFF
--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,11 +1,14 @@
 # https://github.com/tensorflow/serving/blob/2.1.0/tensorflow_serving/tools/docker/Dockerfile
+# Upstream uses 2.1.0 but we bumped the version until the ROCK could be built
+# https://github.com/SeldonIO/seldon-core/blob/v1.17.1/operator/config/manager/configmap.yaml#L23-L24
+# See https://github.com/canonical/seldonio-rocks/issues/37#issuecomment-1716074625
 name: tensorflow-serving
 summary: An image for Seldon Tensorflow Serving
 description: |
   This image is used as part of the Charmed Kubeflow product.
-version: 2.13.0_20.04_1 # <upstream-version>_<base-version>_<Charmed-KF-version>
+version: 2.13.0
 license: Apache-2.0
-base: ubuntu:20.04
+base: ubuntu@20.04
 run-user: _daemon_
 services:
   tensorflow-serving:

--- a/tensorflow-serving/tox.ini
+++ b/tensorflow-serving/tox.ini
@@ -13,41 +13,35 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+    skopeo
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION'
-
-    # run rock tests
-    pytest -vvv --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \\
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *
-deps =
-    juju~=2.9.0
-    pytest
-    pytest-operator
-    ops
-    charmed_kubeflow_chisme
+allowlist_externals =
+    echo
 commands =
-    # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+    echo "WARNING: This is a placeholder test - no test is implemented here."
 
 [testenv:integration]
 passenv = *
@@ -56,16 +50,13 @@ allowlist_externals =
     git
     rm
     tox
-    rockcraft
     sed
 deps =
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
     # clone related charm
     rm -rf {env:LOCAL_CHARM_DIR}
     git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
@@ -74,13 +65,11 @@ commands =
     # upload rock to docker and microk8s cache, replace charm's container with local rock reference
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar --digests=true && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
+             sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
 	         predictor_servers=$(yq e ".data.predictor_servers" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2) && \
-             predictor_servers=$(jq --arg jq_rock $ROCK -r '\''.TENSORFLOW_SERVER.protocols.v2.image=$jq_rock'\'' <<< $predictor_servers) && \
+             predictor_servers=$(jq --arg jq_name $NAME -r '\''.TENSORFLOW_SERVER.protocols.v2.image=$jq_name'\'' <<< $predictor_servers) && \
              predictor_servers=$(jq --arg jq_version $VERSION -r '\''.TENSORFLOW_SERVER.protocols.v2.defaultImageVersion=$jq_version'\'' <<< $predictor_servers) yq e -i ".data.predictor_servers=strenv(predictor_servers)" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2'
     # replace yq safe placeholder with original value
     sed -i "s/namespace: YQ_SAFE/namespace: {{ namespace }}/" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2


### PR DESCRIPTION
We see that [release 1.17.1](https://github.com/SeldonIO/seldon-core/blob/v1.17.1/operator/config/manager/configmap.yaml#L23-L24) still uses `imageVersion` 2.1.0 so we don't need to introduce any changes to this ROCK. However, we still

- update the `version` as per https://github.com/canonical/bundle-kubeflow/issues/747#issuecomment-1841137355
- update `base` since using `:` is deprecated
- refactor `tox.ini` according to https://github.com/canonical/oidc-authservice-rock/pull/14 and https://github.com/canonical/bundle-kubeflow/issues/763
- update `test_rock.py` according to latest changes in chisme https://github.com/canonical/charmed-kubeflow-chisme/pull/81

Refs https://github.com/canonical/seldonio-rocks/issues/37