### PR TITLE
fix(tf-serving): Replace upstream server with rock in integration tests

### DIFF
--- a/tensorflow-serving/tox.ini
+++ b/tensorflow-serving/tox.ini
@@ -69,8 +69,8 @@ commands =
              docker save $DOCKER_IMAGE > $DOCKER_IMAGE.tar && \
              sudo microk8s ctr image import $DOCKER_IMAGE.tar --digests=true && \
 	         predictor_servers=$(yq e ".data.predictor_servers" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2) && \
-             predictor_servers=$(jq --arg jq_name $NAME -r '\''.TENSORFLOW_SERVER.protocols.v2.image=$jq_name'\'' <<< $predictor_servers) && \
-             predictor_servers=$(jq --arg jq_version $VERSION -r '\''.TENSORFLOW_SERVER.protocols.v2.defaultImageVersion=$jq_version'\'' <<< $predictor_servers) yq e -i ".data.predictor_servers=strenv(predictor_servers)" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2'
+             predictor_servers=$(jq --arg jq_name $NAME -r '\''.TENSORFLOW_SERVER.protocols.tensorflow.image=$jq_name'\'' <<< $predictor_servers) && \
+             predictor_servers=$(jq --arg jq_version $VERSION -r '\''.TENSORFLOW_SERVER.protocols.tensorflow.defaultImageVersion=$jq_version'\'' <<< $predictor_servers) yq e -i ".data.predictor_servers=strenv(predictor_servers)" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2'
     # replace yq safe placeholder with original value
     sed -i "s/namespace: YQ_SAFE/namespace: {{ namespace }}/" {env:LOCAL_CHARM_DIR}/src/templates/configmap.yaml.j2
     # run charm integration test with rock


### PR DESCRIPTION
Until now, tests didn't actually test the ROCK (but used the upstream image) since we didn't properly replace the server's image in the charm's `configmap`.