### PR TITLE
fix: Update tensorflow-serving rock

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,7 +12,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      rockcraft-channel: latest/edge
       microk8s-channel: 1.26-strict/stable
       juju-channel: 3.1/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -15,7 +15,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      rockcraft-channel: latest/edge
       microk8s-channel: 1.26-strict/stable
       juju-channel: 3.1/stable
       python-version: "3.8"


### PR DESCRIPTION
- fix tests: Until now, tests didn't actually test the ROCK (but used the upstream image) since we didn't properly replace the server's image in the charm's `configmap`.
- Add `entrypoint-service:tensorflow-serving` along with required `[ args ]` in `command` field to address #83
- ~~Use `rockcraft-channel: latest/edge` in CI (that affects the whole repo) since `entrypoint-service` field was introduced in 1.1.0 which is not yet published to `stable` rockcraft snap. Otherwise, it would [fail with](https://github.com/canonical/seldonio-rocks/actions/runs/7540628075/job/20525653125#step:4:34)~~


### Tests

Tests still fail due to #86. This doesn't look like a major result error and is probably related to round-offs. Thus, I suggest we merge this PR and publish manually the ROCK built in the CI. Once this is done, we 'll update the seldon-server tests accordingly. 

Closes #83