### PR TITLE
ci: Decrease root-reserve-mb to fit the new runner storage

### DIFF
--- a/.github/workflows/build_and_scan_rocks.yaml
+++ b/.github/workflows/build_and_scan_rocks.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Maximise GH runner space
         uses: easimon/maximize-build-space@v7
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 29696
           remove-dotnet: 'true'
           remove-haskell: 'true'
           remove-android: 'true'


### PR DESCRIPTION
ci: Decrease root-reserve-mb to fit the new runner storage

addresses https://github.com/canonical/bundle-kubeflow/issues/813