### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -13,5 +13,5 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -16,5 +16,5 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"


### PR DESCRIPTION
This PR changes the CI to use Juju version `3.4/stable` instead of `3.5/stable`.